### PR TITLE
Feature Request: Add Timestamp and Filter for Outdated Files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ var (
 	dryrun          bool
 	randomFileOrder bool
 	top             int
+	force           bool
 )
 
 const (
@@ -53,7 +54,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		start := time.Now()
-		files, err := fswalker.ReadFiles(path, override)
+		files, err := fswalker.ReadFiles(path, override, force)
 		pterm.Info.Printf("Reading files took: %v\n", time.Since(start))
 		if err != nil {
 			pterm.Error.Printf("Error reading files: %v\n", err)
@@ -226,6 +227,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "Dry run mode - stops before making API calls")
 	rootCmd.PersistentFlags().BoolVar(&randomFileOrder, "random-file-access", false, "Process files in random order")
 	rootCmd.PersistentFlags().IntVar(&top, "top", 0, "Process only this many files (0 for all)")
+	rootCmd.PersistentFlags().BoolVar(&force, "force", false, "Force re-summarization of all files regardless of timestamps")
 
 	rootCmd.MarkPersistentFlagRequired("path")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var (
 	dryrun          bool
 	randomFileOrder bool
 	top             int
-	force           bool
+	onlyOutOfDate   bool
 )
 
 const (
@@ -54,7 +54,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		start := time.Now()
-		files, err := fswalker.ReadFiles(path, override, force)
+		files, err := fswalker.ReadFiles(path, override, onlyOutOfDate)
 		pterm.Info.Printf("Reading files took: %v\n", time.Since(start))
 		if err != nil {
 			pterm.Error.Printf("Error reading files: %v\n", err)
@@ -227,7 +227,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "Dry run mode - stops before making API calls")
 	rootCmd.PersistentFlags().BoolVar(&randomFileOrder, "random-file-access", false, "Process files in random order")
 	rootCmd.PersistentFlags().IntVar(&top, "top", 0, "Process only this many files (0 for all)")
-	rootCmd.PersistentFlags().BoolVar(&force, "force", false, "Force re-summarization of all files regardless of timestamps")
+	rootCmd.PersistentFlags().BoolVar(&onlyOutOfDate, "only-out-of-date", false, "Only process files where updated > summarize_ai_updated")
 
 	rootCmd.MarkPersistentFlagRequired("path")
 }

--- a/internal/frontmatter/frontmatter_test.go
+++ b/internal/frontmatter/frontmatter_test.go
@@ -19,6 +19,7 @@ func TestUpdateFrontmatter(t *testing.T) {
 			expectedContent: `---
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---`,
 			summary: "Test summary",
 			hash:    "TestHash",
@@ -29,6 +30,7 @@ summarize_ai_hash: TestHash
 			expectedContent: `---
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Come Content`,
 			summary: "Test summary",
@@ -41,6 +43,7 @@ Come Content`,
 			expectedContent: `---
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 
 `,
@@ -61,6 +64,7 @@ Content below frontmatter.
 existing_key: existing_value
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 existing_key_lower: existing_value
 ---
 Content below frontmatter.
@@ -79,6 +83,7 @@ Content below frontmatter.
 existing_key: existing_value
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Content below frontmatter.
 `,
@@ -97,6 +102,7 @@ Content below frontmatter.
 existing_key: existing_value
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 
 Content below frontmatter.
@@ -115,6 +121,7 @@ Content below frontmatter.
 unrelated_key: unrelated_value
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Content below frontmatter.
 `,
@@ -184,6 +191,7 @@ summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
 summarize_ai_tags:
   - tag1
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Some content`,
 			summary: "Test summary",
@@ -200,6 +208,7 @@ summarize_ai_tags:
   - tag1
   - tag2
   - tag3
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Some content`,
 			summary: "Test summary",
@@ -224,6 +233,7 @@ summarize_ai_hash: TestHash
 summarize_ai_tags:
   - newtag1
   - newtag2
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Content here
 `,
@@ -246,6 +256,7 @@ Content here
 title: Example
 summarize_ai: "Test summary"
 summarize_ai_hash: TestHash
+summarize_ai_updated: 2025-03-23T10:43
 ---
 Content here
 `,
@@ -282,4 +293,11 @@ Content here
 			}
 		})
 	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/fswalker/fswalker.go
+++ b/internal/fswalker/fswalker.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dhcgn/go-obsidian-ai-sum/internal"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,38 +31,60 @@ type FileInfo struct {
 	CharacterCount int
 }
 
-func shouldProcessFile(content []byte, override, onlyOutOfDate bool) bool {
+// shouldProcessFile checks if a file should be processed based on its content and file properties in fontmatter
+// always=false and includeOutOfDate=false: process if file is incomplete (ai summary fields are imcomplete)
+// always=false and includeOutOfDate=true: process if file is incomplete or the summarize_ai_updated date is older than the updated date in frontmatter
+// always=true and includeOutOfDate=false: process the file regardless of its content
+// always=true and includeOutOfDate=true: process the file regardless of its content
+func shouldProcessFile(content []byte, always, includeOutOfDate bool) bool {
 	// Empty files are skipped
 	if len(content) == 0 {
 		return false
 	}
 
 	// If override is true, always process
-	if override {
+	if always {
 		return true
 	}
 
-	// Check for existing summary
-	hasSummary := strings.Contains(string(content), "summarize_ai:")
-	if !hasSummary {
+	// If the file has no frontmatter, it is incomplete and should be processed
+	hasFontmatter := strings.HasPrefix(string(content), internal.FontmatterDelimiter)
+	if !hasFontmatter {
+		return true
+	}
+
+	// Extract content between the first and second FontmatterDelimiter
+	parts := strings.SplitN(string(content), internal.FontmatterDelimiter, 3)
+	if len(parts) < 3 {
+		return true // If there's no second delimiter, consider the file incomplete
+	}
+	frontmatterContent := parts[1]
+
+	// Check for existing summary fields, if any of them are missing the file is incomplete and will be processed
+	hasAllProps := strings.Contains(frontmatterContent, internal.FontmatterSummarize_ai+":") &&
+		strings.Contains(frontmatterContent, internal.FontmatterSummarize_ai_hash+":") &&
+		strings.Contains(frontmatterContent, internal.FontmatterSummarize_ai_tags+":") &&
+		strings.Contains(frontmatterContent, internal.FontmatterSummarize_ai_updated+":")
+	if !hasAllProps {
 		return true
 	}
 
 	// At this point, we have a file with an existing summary
 	// Only continue if we're checking for outdated files
-	if !onlyOutOfDate {
+	if !includeOutOfDate {
 		return false
 	}
 
 	var frontmatter map[string]interface{}
-	if err := yaml.Unmarshal(content, &frontmatter); err != nil {
+	if err := yaml.Unmarshal([]byte(frontmatterContent), &frontmatter); err != nil {
 		return false
 	}
 
-	// For onlyOutOfDate mode, we need both date fields
-	updatedStr, hasUpdated := frontmatter["updated"].(string)
-	summarizeAIUpdatedStr, hasSummarizeUpdated := frontmatter["summarize_ai_updated"].(string)
+	// For includeOutOfDate mode, we need both date fields
+	updatedStr, hasUpdated := frontmatter[internal.FontmatterUpdated].(string)
+	summarizeAIUpdatedStr, hasSummarizeUpdated := frontmatter[internal.FontmatterSummarize_ai_updated].(string)
 
+	// If either date field is missing, we consider the file incomplete and process it
 	if !hasUpdated || !hasSummarizeUpdated {
 		return false
 	}

--- a/internal/fswalker/fswalker_test.go
+++ b/internal/fswalker/fswalker_test.go
@@ -1,0 +1,103 @@
+package fswalker
+
+import (
+	"testing"
+)
+
+func TestShouldProcessFile(t *testing.T) {
+	tests := []struct {
+		name             string
+		content          []byte
+		always           bool
+		includeOutOfDate bool
+		expected         bool
+	}{
+		{
+			name:     "Empty file",
+			content:  []byte(""),
+			always:   false,
+			expected: false,
+		},
+		{
+			name:     "Always true, process regardless of content",
+			content:  []byte("Some content"),
+			always:   true,
+			expected: true,
+		},
+		{
+			name:     "No frontmatter, should process",
+			content:  []byte("Some content without frontmatter"),
+			always:   false,
+			expected: true,
+		},
+		{
+			name: "Incomplete frontmatter",
+			content: []byte(`---
+summarize_ai: "summary"
+
+Content`),
+			always:   false,
+			expected: true,
+		},
+		{
+			name: "Incomplete frontmatter, missing fields",
+			content: []byte(`---
+summarize_ai: "summary"
+---
+Content`),
+			always:   false,
+			expected: true,
+		},
+		{
+			name: "Complete frontmatter, not outdated",
+			content: []byte(`---
+summarize_ai: "summary"
+summarize_ai_hash: "hash"
+summarize_ai_tags: "tags"
+summarize_ai_updated: "2023-01-01T12:00"
+updated: "2023-01-01T12:00"
+---
+Content`),
+			always:           false,
+			includeOutOfDate: false,
+			expected:         false,
+		},
+		{
+			name: "Complete frontmatter, outdated",
+			content: []byte(`---
+summarize_ai: "summary"
+summarize_ai_hash: "hash"
+summarize_ai_tags: "tags"
+summarize_ai_updated: "2023-01-01T12:00"
+updated: "2023-01-02T12:00"
+---
+Content`),
+			always:           false,
+			includeOutOfDate: true,
+			expected:         true,
+		},
+		{
+			name: "Malformed frontmatter, should process",
+			content: []byte(`---
+summarize_ai: "summary"
+summarize_ai_hash: "hash"
+summarize_ai_tags: "tags"
+summarize_ai_updated: "invalid-date"
+updated: "2023-01-02T12:00"
+---
+Content`),
+			always:           false,
+			includeOutOfDate: true,
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldProcessFile(tt.content, tt.always, tt.includeOutOfDate)
+			if result != tt.expected {
+				t.Errorf("shouldProcessFile() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,16 @@
+package internal
+
+const (
+	FontmatterDelimiter = "---"
+)
+
+const (
+	FontmatterSummarize_ai         = "summarize_ai"
+	FontmatterSummarize_ai_hash    = "summarize_ai_hash"
+	FontmatterSummarize_ai_tags    = "summarize_ai_tags"
+	FontmatterSummarize_ai_updated = "summarize_ai_updated"
+)
+
+const (
+	FontmatterUpdated = "updated"
+)


### PR DESCRIPTION
Related to #4

Add timestamp field and filter for outdated files.

* Add `summarize_ai_updated` field to the frontmatter in `internal/frontmatter/frontmatter.go`.
* Update `UpdateFrontmatter` function to include `summarize_ai_updated` field.
* Add logic to compare `updated` and `summarize_ai_updated` fields to filter outdated files in `internal/fswalker/fswalker.go`.
* Update `ReadFiles` function to include filtering logic for outdated files.
* Integrate filtering logic for outdated files into the CLI workflow in `cmd/root.go`.
* Add test cases to verify handling of `summarize_ai_updated` field in `internal/frontmatter/frontmatter_test.go`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dhcgn/go-obsidian-ai-sum/pull/6?shareId=54751973-159b-4f4c-a7d8-18fb5542dbec).